### PR TITLE
fix: embed Info.plist in wwkd binary for sandbox CFBundleIdentifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,11 @@ fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 Provide a short summary of this project*.json
+
+# Build artifacts
+dist/
+
+# Stray SQLite files from accidental CLI invocations
+--help
+--help-shm
+--help-wal

--- a/Package.swift
+++ b/Package.swift
@@ -99,8 +99,20 @@ let package = Package(
             name: "WellWhaddyaKnowAgent",
             dependencies: ["Storage", "Sensors", "CoreModel", "Timeline", "XPCProtocol", "Reporting"],
             path: "Sources/WellWhaddyaKnowAgent",
+            exclude: [
+                "Info.plist",
+                "wwkd.entitlements",
+            ],
             swiftSettings: [
                 .unsafeFlags(["-parse-as-library"])
+            ],
+            linkerSettings: [
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "Sources/WellWhaddyaKnowAgent/Info.plist",
+                ])
             ]
         ),
 

--- a/Sources/WellWhaddyaKnowAgent/Info.plist
+++ b/Sources/WellWhaddyaKnowAgent/Info.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.daylily.wellwhaddyaknow.agent</string>
+    <key>CFBundleName</key>
+    <string>wwkd</string>
+    <key>CFBundleExecutable</key>
+    <string>wwkd</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+</dict>
+</plist>
+

--- a/Sources/WellWhaddyaKnowAgent/wwkd.entitlements
+++ b/Sources/WellWhaddyaKnowAgent/wwkd.entitlements
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.daylily.wellwhaddyaknow</string>
+    </array>
+</dict>
+</plist>
+


### PR DESCRIPTION
## Problem

`wwkd` crashes on reboot with `EXC_BREAKPOINT (SIGTRAP)` in `libsystem_secinit` at `_libsecinit_appsandbox`:

```
asiSignatures: ["Unable to get bundle identifier for container id wwkd: Unable to get bundle identifier because Info.plist from code signature information has no value for kCFBundleIdentifierKey."]
```

The sandboxed agent binary had no `CFBundleIdentifier` in its code signature, so `libsystem_secinit` crashed before any Swift code ran.

## Fix

- **`Sources/WellWhaddyaKnowAgent/Info.plist`** — new file with `CFBundleIdentifier=com.daylily.wellwhaddyaknow.agent`
- **`Package.swift`** — embed Info.plist into wwkd Mach-O binary via `-sectcreate __TEXT __info_plist` linker flag
- **`Sources/WellWhaddyaKnowAgent/wwkd.entitlements`** — agent-specific entitlements (sandbox + app-groups)
- **`scripts/build-app.sh`** — replace non-existent `--info` flag with `-i` identifier; use agent-specific entitlements
- **`.gitignore`** — ignore `dist/` and stray SQLite artifacts

## Verification

- `otool` confirms `__info_plist` section embedded in binary
- `codesign -dvvv` shows `Identifier=com.daylily.wellwhaddyaknow.agent`, `Info.plist entries=6`
- 222 tests pass
- Agent launches successfully from app bundle path

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author