### PR TITLE
feat: CLI UX improvements + version string update (0.3.2)

### DIFF
--- a/Sources/WellWhaddyaKnowCLI/CLIError.swift
+++ b/Sources/WellWhaddyaKnowCLI/CLIError.swift
@@ -17,7 +17,18 @@ enum CLIError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .databaseNotFound(let path):
-            return "Database not found at: \(path)"
+            return """
+            Database not found at: \(path)
+
+            The wwkd agent may not be running or has never been started.
+
+            To start the agent:
+              wwk agent install    # Install as login item (starts at login)
+              wwk agent start      # Start now
+
+            To check agent status:
+              wwk agent status
+            """
         case .databaseError(let message):
             return "Database error: \(message)"
         case .agentNotRunning:

--- a/Sources/WellWhaddyaKnowCLI/Commands/StatusCommand.swift
+++ b/Sources/WellWhaddyaKnowCLI/Commands/StatusCommand.swift
@@ -41,7 +41,7 @@ struct Status: AsyncParsableCommand {
                     "current_app": currentApp as Any,
                     "current_title": currentTitle as Any,
                     "accessibility_status": "unknown",
-                    "agent_version": "0.1.0"
+                    "agent_version": "0.3.2"
                 ]
                 if let data = try? JSONSerialization.data(withJSONObject: output, options: [.prettyPrinted, .sortedKeys]),
                    let json = String(data: data, encoding: .utf8) {
@@ -56,7 +56,7 @@ struct Status: AsyncParsableCommand {
                     print("Current Title: \(title)")
                 }
                 print("Accessibility: unknown (check via agent)")
-                print("Agent Version: 0.1.0")
+                print("Agent Version: 0.3.2")
             }
         } catch let error as CLIError {
             if options.json {

--- a/Sources/WellWhaddyaKnowCLI/WWK.swift
+++ b/Sources/WellWhaddyaKnowCLI/WWK.swift
@@ -10,7 +10,7 @@ struct WWK: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "wwk",
         abstract: "WellWhaddyaKnow - macOS time tracking CLI",
-        version: "0.1.0",
+        version: "0.3.2",
         subcommands: [
             Status.self,
             Summary.self,


### PR DESCRIPTION
## Changes

### Improved error message for missing database
When the wwkd agent has never run, CLI commands now show helpful guidance instead of a bare "Database not found" error:

```
Database not found at: .../wwk.sqlite

The wwkd agent may not be running or has never been started.

To start the agent:
  wwk agent install    # Install as login item (starts at login)
  wwk agent start      # Start now

To check agent status:
  wwk agent status
```

### Version string updates
- `wwk --version` now reports `0.3.2` (was `0.1.0`)
- `wwk status` JSON and text output now report `agent_version: 0.3.2`

### Tests
- 222/222 tests pass
- Zero build warnings

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author