### PR TITLE
feat: configurable display timezone, inactive time in reports, conditional bar annotations

### DIFF
--- a/Sources/WellWhaddyaKnowAgent/Agent+EventHandlers.swift
+++ b/Sources/WellWhaddyaKnowAgent/Agent+EventHandlers.swift
@@ -105,6 +105,9 @@ extension Agent {
         // Only emit activity events when working (SPEC.md 5.4)
         guard state.isWorking else { return }
 
+        // Don't track our own app or agent — they aren't user work
+        guard !Self.excludedBundleIds.contains(bundleId) else { return }
+
         let timestampUs = Int64(timestamp.timeIntervalSince1970 * 1_000_000)
 
         // Ensure app exists in dimension table
@@ -177,6 +180,9 @@ extension Agent {
         // Get current frontmost app (sensor is guaranteed to exist after start())
         guard let foregroundAppSensor = foregroundAppSensor,
               let appInfo = foregroundAppSensor.getCurrentFrontmostApp() else { return }
+
+        // Don't track our own app or agent
+        guard !Self.excludedBundleIds.contains(appInfo.bundleId) else { return }
 
         let appId = try eventWriter.ensureApplication(
             bundleId: appInfo.bundleId,

--- a/Sources/WellWhaddyaKnowAgent/Agent.swift
+++ b/Sources/WellWhaddyaKnowAgent/Agent.swift
@@ -17,8 +17,15 @@ public enum AgentError: Error {
 public actor Agent: SensorEventHandler {
     
     // MARK: - Configuration
-    
+
     public static let agentVersion = "1.0.0"
+
+    /// Bundle IDs to exclude from activity tracking.
+    /// The app should not track itself or its own agent.
+    static let excludedBundleIds: Set<String> = [
+        "com.daylily.wellwhaddyaknow",
+        "com.daylily.wellwhaddyaknow.agent",
+    ]
     
     // MARK: - State (internal for extensions)
 

--- a/Sources/WellWhaddyaKnowApp/TodayTotalCalculator.swift
+++ b/Sources/WellWhaddyaKnowApp/TodayTotalCalculator.swift
@@ -48,7 +48,7 @@ final class TodayTotalCalculator {
         }
 
         // Calculate today's time range in microseconds
-        let calendar = Calendar.current
+        let calendar = DisplayTimezoneHelper.calendar
         let now = Date()
         guard let startOfDay = calendar.startOfDay(for: now) as Date? else {
             return 0.0

--- a/Sources/WellWhaddyaKnowCLI/Commands/DBCommand.swift
+++ b/Sources/WellWhaddyaKnowCLI/Commands/DBCommand.swift
@@ -80,10 +80,10 @@ struct DBInfo: AsyncParsableCommand {
                 ]
             ]
             if let earliest = dateRange.earliest {
-                output["earliest_event"] = formatLocalTimestamp(earliest)
+                output["earliest_event"] = formatLocalTimestamp(earliest, timeZone: options.resolvedTimezone)
             }
             if let latest = dateRange.latest {
-                output["latest_event"] = formatLocalTimestamp(latest)
+                output["latest_event"] = formatLocalTimestamp(latest, timeZone: options.resolvedTimezone)
             }
             if let data = try? JSONSerialization.data(withJSONObject: output, options: [.prettyPrinted, .sortedKeys]),
                let json = String(data: data, encoding: .utf8) {
@@ -103,8 +103,8 @@ struct DBInfo: AsyncParsableCommand {
             print("")
             if let earliest = dateRange.earliest, let latest = dateRange.latest {
                 print("Date Range:")
-                print("  Earliest: \(formatLocalTimestamp(earliest))")
-                print("  Latest: \(formatLocalTimestamp(latest))")
+                print("  Earliest: \(formatLocalTimestamp(earliest, timeZone: options.resolvedTimezone))")
+                print("  Latest: \(formatLocalTimestamp(latest, timeZone: options.resolvedTimezone))")
             } else {
                 print("Date Range: No events recorded")
             }

--- a/Sources/WellWhaddyaKnowCLI/Commands/EditCommand.swift
+++ b/Sources/WellWhaddyaKnowCLI/Commands/EditCommand.swift
@@ -37,8 +37,8 @@ struct EditDelete: AsyncParsableCommand {
 
     mutating func run() async throws {
         // Validate date range
-        let startTsUs = try parseISODate(from)
-        let endTsUs = try parseISODate(to)
+        let startTsUs = try parseISODate(from, timeZone: options.resolvedTimezone)
+        let endTsUs = try parseISODate(to, timeZone: options.resolvedTimezone)
 
         guard startTsUs < endTsUs else {
             printError("Start date must be before end date")
@@ -96,8 +96,8 @@ struct EditAdd: AsyncParsableCommand {
 
     mutating func run() async throws {
         // Validate date range
-        let startTsUs = try parseISODate(from)
-        let endTsUs = try parseISODate(to)
+        let startTsUs = try parseISODate(from, timeZone: options.resolvedTimezone)
+        let endTsUs = try parseISODate(to, timeZone: options.resolvedTimezone)
 
         guard startTsUs < endTsUs else {
             printError("Start date must be before end date")

--- a/Sources/WellWhaddyaKnowCLI/Commands/ExportCommand.swift
+++ b/Sources/WellWhaddyaKnowCLI/Commands/ExportCommand.swift
@@ -39,8 +39,9 @@ struct Export: AsyncParsableCommand {
     mutating func run() async throws {
         let path = options.db ?? getDefaultDatabasePath()
 
-        let startTsUs = try parseISODate(from)
-        let endTsUs = try parseISODate(to)
+        let tz = options.resolvedTimezone
+        let startTsUs = try parseISODate(from, timeZone: tz)
+        let endTsUs = try parseISODate(to, timeZone: tz)
 
         guard startTsUs < endTsUs else {
             printError("Start date must be before end date")
@@ -52,7 +53,7 @@ struct Export: AsyncParsableCommand {
         let identity = try reader.loadIdentity()
 
         // Get timezone offset
-        let tzOffsetSeconds = TimeZone.current.secondsFromGMT()
+        let tzOffsetSeconds = tz.secondsFromGMT()
 
         let output: String
         switch format {

--- a/Sources/WellWhaddyaKnowCLI/Commands/TagCommand.swift
+++ b/Sources/WellWhaddyaKnowCLI/Commands/TagCommand.swift
@@ -41,11 +41,11 @@ struct TagList: AsyncParsableCommand {
                 var dict: [String: Any] = [
                     "tag_id": tag.tagId,
                     "name": tag.name,
-                    "created": formatLocalTimestamp(tag.createdTsUs),
+                    "created": formatLocalTimestamp(tag.createdTsUs, timeZone: options.resolvedTimezone),
                     "is_retired": tag.isRetired
                 ]
                 if let retired = tag.retiredTsUs {
-                    dict["retired"] = formatLocalTimestamp(retired)
+                    dict["retired"] = formatLocalTimestamp(retired, timeZone: options.resolvedTimezone)
                 }
                 return dict
             }
@@ -86,8 +86,8 @@ struct TagApply: AsyncParsableCommand {
     var tag: String
 
     mutating func run() async throws {
-        let startTsUs = try parseISODate(from)
-        let endTsUs = try parseISODate(to)
+        let startTsUs = try parseISODate(from, timeZone: options.resolvedTimezone)
+        let endTsUs = try parseISODate(to, timeZone: options.resolvedTimezone)
 
         guard startTsUs < endTsUs else {
             printError("Start date must be before end date")
@@ -135,8 +135,8 @@ struct TagRemove: AsyncParsableCommand {
     var tag: String
 
     mutating func run() async throws {
-        let startTsUs = try parseISODate(from)
-        let endTsUs = try parseISODate(to)
+        let startTsUs = try parseISODate(from, timeZone: options.resolvedTimezone)
+        let endTsUs = try parseISODate(to, timeZone: options.resolvedTimezone)
 
         guard startTsUs < endTsUs else {
             printError("Start date must be before end date")


### PR DESCRIPTION
## Summary

- Add `DisplayTimezoneHelper` shared utility for resolving preferred timezone
- Add timezone picker to Preferences → General tab with searchable IANA identifiers
- Replace `Calendar.current` / `TimeZone.current` with preferred timezone throughout GUI
- Show timezone label with globe icon in Reports tab
- Add `--timezone` CLI flag to `GlobalOptions` (resolves: flag → UserDefaults → system)
- Calculate inactive/sleep time in reports (range duration minus active time)
- Append synthetic "Inactive" row with gray bar in chart
- Conditional bar annotation: show hours label only when bar ≥ 10% of max
- Prevent self-tracking: exclude `com.daylily.wellwhaddyaknow` bundle IDs from agent

## Technical Notes

- All times stored in UTC (unchanged) — display timezone is presentation-only
- 222 tests pass, zero build warnings

## Files Changed (11)

- `Sources/WellWhaddyaKnowAgent/Agent.swift` — excludedBundleIds
- `Sources/WellWhaddyaKnowAgent/Agent+EventHandlers.swift` — self-tracking filter
- `Sources/WellWhaddyaKnowApp/PreferencesWindow.swift` — DisplayTimezoneHelper + picker UI
- `Sources/WellWhaddyaKnowApp/TodayTotalCalculator.swift` — preferred timezone
- `Sources/WellWhaddyaKnowApp/ViewerWindow.swift` — timezone, inactive time, conditional annotation
- `Sources/WellWhaddyaKnowCLI/WWK.swift` — --timezone flag
- `Sources/WellWhaddyaKnowCLI/Commands/*.swift` — pass resolvedTimezone through

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author