### PR TITLE
fix: Reports tab date range and inactive time calculation (0.3.4)

### DIFF
--- a/Sources/WellWhaddyaKnowCLI/WWK.swift
+++ b/Sources/WellWhaddyaKnowCLI/WWK.swift
@@ -10,7 +10,7 @@ struct WWK: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "wwk",
         abstract: "WellWhaddyaKnow - macOS time tracking CLI",
-        version: "0.3.2",
+        version: "0.3.4",
         subcommands: [
             Status.self,
             Summary.self,


### PR DESCRIPTION
## Summary

Fixes two bugs in the Reports tab:

### Bug 1: "Today" preset shows ~24h instead of midnight-to-now
- `DateRangePreset.dateRange()` was returning `endOfDay(23:59:59)` for all presets including Today
- **Fix**: Presets that include the current day (Today, This Week, This Month, Last 7/30 Days, Last 12 Months, YTD) now return `now` as end
- Yesterday still returns `endOfDay` (correct for completed day)

### Bug 2: Inactive time exceeds active time
- `rangeDurationSeconds` was computed from `reportEndTime(23:59:59) - reportStartTime(midnight) = ~24h`
- **Fix**: `effectiveEnd = min(reportEndTime, Date())` caps range at now

### Also
- Initial default values for `endTime` and `reportEndTime` changed from 23:59:59 to `Date()`
- CLI version string updated to 0.3.4

222 tests pass, zero build warnings.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author