### PR TITLE
docs: refresh documentation, add non-admin cask install guidance (0.3.5)

### DIFF
--- a/Sources/WellWhaddyaKnowCLI/WWK.swift
+++ b/Sources/WellWhaddyaKnowCLI/WWK.swift
@@ -10,7 +10,7 @@ struct WWK: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "wwk",
         abstract: "WellWhaddyaKnow - macOS time tracking CLI",
-        version: "0.3.4",
+        version: "0.3.5",
         subcommands: [
             Status.self,
             Summary.self,

--- a/docs/app-store.md
+++ b/docs/app-store.md
@@ -13,6 +13,8 @@ This document covers entitlements, privacy manifest, and App Store compliance fo
 <dict>
     <key>com.apple.security.app-sandbox</key>
     <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
     <key>com.apple.security.application-groups</key>
     <array>
         <string>group.com.daylily.wellwhaddyaknow</string>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,102 +45,132 @@ WellWhaddyaKnow uses an **event-sourcing architecture** where all state changes 
 2. **Append-only**: New events are always appended, never updated
 3. **Deterministic replay**: Timeline can be rebuilt from events at any time
 4. **Audit trail**: Complete history of all changes is preserved
+5. **UTC storage**: All timestamps stored as UTC microseconds; display timezone is presentation-only
 
-### Event Types
+### Event Tables
 
 | Table | Description | Trigger |
 |-------|-------------|---------|
-| `system_state_events` | Lock/unlock, sleep/wake, shutdown | System notifications |
-| `raw_activity_events` | App/window changes | Foreground app sensor |
-| `user_edit_events` | Deletes, adds, tag applications | User actions |
-| `tags` | Tag definitions | User creates tag |
+| `system_state_events` | State snapshots (sleep/wake, lock/unlock, agent lifecycle) | System notifications, IOKit, timer poll |
+| `raw_activity_events` | Foreground app/window snapshots | App activation, AX title change, poll |
+| `user_edit_events` | Deletes, adds, tag/untag, undo | User actions via UI or CLI |
+
+### Dimension Tables
+
+| Table | Description |
+|-------|-------------|
+| `applications` | Deduplicated app bundle IDs and display names |
+| `window_titles` | Deduplicated window title strings |
+| `tags` | Tag definitions with optional retirement |
 
 ### Timeline Building
 
 The timeline is computed by:
 
 1. Loading all events for a date range
-2. Building "effective segments" from raw activity
-3. Applying user edits (deletes, adds)
-4. Splitting by day boundaries
-5. Computing aggregations
+2. Building "effective segments" from raw activity intersected with working intervals
+3. Filtering active edits (resolving undo chains recursively)
+4. Applying user edits (deletes, adds, tags)
+5. Splitting by day boundaries
+6. Computing aggregations
 
 ```
 Raw Events → Timeline Builder → Effective Segments → Reports
                     ↑
-              User Edits
+         User Edits (filtered by undo resolution)
 ```
 
 ## State Machine
 
-The agent maintains a state machine with these states:
+The agent maintains a boolean-flag state with a derived `isWorking` property:
 
-| State | Description |
-|-------|-------------|
-| `working` | Screen unlocked, user active |
-| `notWorking` | Screen locked or system sleeping |
-| `unknown` | Initial state before first event |
+```
+isWorking = !isPausedByUser && isSystemAwake && isSessionOnConsole && !isScreenLocked
+```
+
+| Flag | Source |
+|------|--------|
+| `isSystemAwake` | IOKit / NSWorkspace sleep/wake notifications |
+| `isSessionOnConsole` | `CGSessionCopyCurrentDictionary` (fast user switching) |
+| `isScreenLocked` | `CGSessionCopyCurrentDictionary` (screen lock state) |
+| `isPausedByUser` | Manual pause via UI/CLI (resets on agent restart) |
+
+Initial state is conservative: `isSessionOnConsole=false, isScreenLocked=true` until the first probe.
 
 ### State Transitions
 
 ```
-                    unlock
-    ┌──────────────────────────────────┐
-    │                                  ▼
-┌───┴───┐                         ┌────────┐
-│  not  │                         │working │
-│working│                         │        │
-└───┬───┘                         └────┬───┘
-    ▲                                  │
-    │                                  │
-    └──────────────────────────────────┘
-                  lock/sleep
+                    unlock / wake / resume
+    ┌────────────────────────────────────────┐
+    │                                        ▼
+┌───┴────────┐                         ┌──────────┐
+│ isWorking  │                         │ isWorking │
+│  = false   │                         │  = true   │
+└───┬────────┘                         └────┬─────┘
+    ▲                                       │
+    │                                       │
+    └───────────────────────────────────────┘
+              lock / sleep / pause / switch-out
 ```
 
 ## Sensors
 
 ### SessionStateSensor
 - Monitors screen lock/unlock via `CGSessionCopyCurrentDictionary`
-- Emits `screenLocked` and `screenUnlocked` events
+- Polls `kCGSessionOnConsoleKey` and `CGSSessionScreenIsLocked`
+- Emits `state_change` events when `isWorking` transitions
 
 ### SleepWakeSensor
-- Monitors system sleep/wake via `NSWorkspace` notifications
-- Emits `systemWillSleep`, `systemDidWake`, `systemWillShutdown`
+- Monitors system sleep/wake via `NSWorkspace` notifications and IOKit
+- Emits `sleep`, `wake`, `poweroff` events
 
 ### ForegroundAppSensor
 - Monitors active application via `NSWorkspace.didActivateApplicationNotification`
-- Emits app bundle ID and display name
+- Records `app_id` (FK into `applications` dimension table) and process ID
+- Self-tracking prevention: excludes `com.daylily.wellwhaddyaknow` bundle IDs
 
 ### AccessibilitySensor
-- Captures window titles via Accessibility API
-- Requires user permission
-- Falls back gracefully if permission denied
+- Captures window titles via macOS Accessibility API (`AXUIElementCopyAttributeValue`)
+- Monitors `AXFocusedWindowChanged` and `AXTitleChanged` notifications
+- Records `title_id` (FK into `window_titles` dimension table)
+- Falls back gracefully if permission denied; records `ax_error_code` on failure
 
 ## Data Flow
 
 ```
 1. Sensor detects change
-2. Agent state machine processes event
-3. Event appended to SQLite (immutable)
-4. UI/CLI queries timeline builder
+2. Agent state machine updates boolean flags, derives isWorking
+3. Event appended to SQLite (immutable, UTC microseconds)
+4. UI/CLI queries timeline builder (reads directly via WAL)
 5. Timeline builder computes effective segments
-6. Results displayed to user
+6. Display timezone applied at presentation layer
 ```
 
-## XPC Protocol
+## IPC Protocol
 
-The menu bar app and CLI communicate with the agent via XPC:
+The menu bar app and CLI communicate with the agent via **JSON-RPC over Unix domain sockets** (not Apple XPC). The socket path is derived from the app group container.
 
-| Command | Direction | Description |
-|---------|-----------|-------------|
-| `getStatus` | App → Agent | Get current working state |
-| `submitEdit` | App → Agent | Submit delete/add/tag operation |
-| `ping` | App → Agent | Health check |
+| Method | Direction | Description |
+|--------|-----------|-------------|
+| `getStatus` | Client → Agent | Current working state, app, title, AX status |
+| `submitDeleteRange` | Client → Agent | Delete a time range |
+| `submitAddRange` | Client → Agent | Add a manual time range |
+| `submitUndoEdit` | Client → Agent | Undo a previous edit |
+| `applyTag` | Client → Agent | Apply tag to time range |
+| `removeTag` | Client → Agent | Remove tag from time range |
+| `listTags` | Client → Agent | List all tags |
+| `createTag` | Client → Agent | Create a new tag |
+| `retireTag` | Client → Agent | Retire (soft-delete) a tag |
+| `exportTimeline` | Client → Agent | Export timeline to CSV/JSON |
+| `getHealth` | Client → Agent | DB integrity, permissions, uptime |
+| `verifyDatabase` | Client → Agent | Run `PRAGMA integrity_check` |
+| `pauseTracking` | Client → Agent | Manually pause tracking |
+| `resumeTracking` | Client → Agent | Resume after manual pause |
 
 ## Concurrency Model
 
 - **Single writer**: Only the agent writes to SQLite
-- **Multiple readers**: App and CLI can read directly
+- **Multiple readers**: App and CLI can read directly via WAL
 - **WAL mode**: Enables concurrent reads during writes
-- **Actor isolation**: Swift actors for thread safety
-
+- **Actor isolation**: The `Agent` is a Swift actor; sensors dispatch events to it
+- **Sendable compliance**: All shared types conform to `Sendable` (Swift 6 strict concurrency)


### PR DESCRIPTION
## Changes

- **README.md**: Add `--appdir=~/Applications` for non-admin Homebrew cask users, clarify admin/sudo requirement, cross-reference in multi-user note
- **docs/architecture.md**: Fix IPC protocol (JSON-RPC over Unix sockets, all 14 methods), correct state machine to boolean-flag model with derived `isWorking`
- **docs/datastore.md**: Complete rewrite matching actual `Schema.swift` — fixed all table definitions, column names, event kinds, dimension tables
- **docs/cli.md**: Add Global Options section, `wwk agent` subcommands, timezone documentation, updated date examples
- **docs/app-store.md**: Add missing `files.user-selected.read-write` entitlement
- **WWK.swift**: Bump CLI version to 0.3.5

222 tests pass, zero build warnings.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author