### PR TITLE
feat: agent lifecycle CLI plist deference + report visualization toggle

### DIFF
--- a/Sources/WellWhaddyaKnowApp/WellWhaddyaKnowApp.swift
+++ b/Sources/WellWhaddyaKnowApp/WellWhaddyaKnowApp.swift
@@ -31,6 +31,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Clean up resources
         menuBarController?.stopPolling()
 
+        // If a CLI-installed plist manages the agent, don't kill it on GUI quit.
+        // launchd will keep it running (or restart it) independently of the app.
+        let cliPlistManaged = FileManager.default.fileExists(
+            atPath: AgentLifecycleManager.cliPlistPath
+        )
+        if cliPlistManaged {
+            return
+        }
+
         // Stop the background agent (wwkd) gracefully via SIGTERM.
         // The agent handles SIGTERM by stopping sensors, emitting agent_stop event,
         // closing the database, removing the IPC socket, and exiting.


### PR DESCRIPTION
## Summary

Two features in one branch:

### 1. Agent Lifecycle — CLI Plist Deference

Fixes the conflict between SMAppService (GUI) and CLI-installed launchd plist both using the same `com.daylily.wellwhaddyaknow.agent` label.

**Changes:**
- `AgentLifecycleManager` detects CLI plist at `~/Library/LaunchAgents/com.daylily.wellwhaddyaknow.agent.plist` and defers to it (skips SMAppService registration)
- `wwk agent install` bootouts the SMAppService label before bootstrapping
- GUI `applicationWillTerminate` skips killing agent when CLI plist exists
- Diagnostics UI shows CLI-managed status

### 2. Reports Tab Visualization Toggle

Adds three visualization modes to the Reports tab:

| Mode | Description |
|------|-------------|
| **Table** (default) | Existing table + pie chart |
| **Hourly Bar** | Stacked bar chart by hour of day |
| **Timeline** | Gantt chart with RectangleMark, gaps shown as gray bars |

**New code:**
- `ReportVisualizationMode` enum with segmented picker
- `Aggregations.totalsByHour()` — splits segments at hour boundaries, groups by app/appWindow/tag
- `HourlyBarChartView` — SwiftUI Charts stacked BarMark
- `TimelineGanttView` — SwiftUI Charts RectangleMark with gap visualization
- 6 new unit tests for `totalsByHour()`

**Gap/sleep coverage:** `.sleep`, `.wake`, `.poweroff` events are already captured via `SystemStateEventKind` and appear as `.unobservedGap` segments rendered as semi-transparent gray bars labeled `⏸ Gap`.

## Test Results

- **228 tests pass** (up from 222)
- **0 warnings**
- Build clean (`swift build -c release`)

## Files Changed

| File | Change |
|------|--------|
| `Aggregations.swift` | +`HourlyGroupBy` enum, +`totalsByHour()`, +`labelsForSegment()`, +`splitAtHourBoundaries()` |
| `ViewerWindow.swift` | +`ReportVisualizationMode`, +`HourlyBarChartView`, +`TimelineGanttView`, updated `ReportsTabView` |
| `AgentLifecycleManager.swift` | CLI plist detection and deferral |
| `AgentCommand.swift` | Bootout SMAppService label before bootstrap |
| `WellWhaddyaKnowApp.swift` | Skip killing agent when CLI-managed |
| `PreferencesWindow.swift` | CLI-managed indicator in diagnostics |
| `AggregationTests.swift` | 6 new tests for `totalsByHour()` |

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author