### PR TITLE
feat: add inspirational quotes to README and GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A **local-only** macOS time tracker that records how time passed on your machine
 
 **No timers. No idle detection. No cloud. No telemetry.**
 
+> *"Time is an illusion, lunchtime doubly so."*
+> — **Ford Prefect**, *The Hitchhiker's Guide to the Galaxy*
+
 ## What It Does
 
 - 📊 **Automatic tracking**: Records foreground app and window title when your screen is unlocked
@@ -172,6 +175,9 @@ wwk today           # today's time breakdown by app
 ```
 
 ## Usage
+
+> *"Over time, you spend too much time thinking about what you need to do, and not doing what you need to do."*
+> — **Mel Robbins**
 
 ### Menu Bar App
 

--- a/Sources/WellWhaddyaKnowApp/PreferencesWindow.swift
+++ b/Sources/WellWhaddyaKnowApp/PreferencesWindow.swift
@@ -901,6 +901,19 @@ struct AboutPreferencesView: View {
 
             Divider()
 
+            VStack(spacing: 2) {
+                Text("\"Time is an illusion, lunchtime doubly so.\"")
+                    .font(.system(.callout, design: .serif))
+                    .italic()
+                    .foregroundColor(.accentColor)
+                Text("— Ford Prefect, The Hitchhiker's Guide to the Galaxy")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.vertical, 4)
+
+            Divider()
+
             VStack(spacing: 8) {
                 Link("View on GitHub", destination: URL(string: "https://github.com/Daylily-Informatics/well-whaddya-know")!)
                 Link("Privacy Policy", destination: URL(string: "https://github.com/Daylily-Informatics/well-whaddya-know/blob/main/PRIVACY.md")!)

--- a/Sources/WellWhaddyaKnowApp/ViewerWindow.swift
+++ b/Sources/WellWhaddyaKnowApp/ViewerWindow.swift
@@ -1417,6 +1417,22 @@ struct ReportsTabView: View {
                         }
                         .padding()
                     }
+
+                    // Motivational footer
+                    HStack {
+                        Spacer()
+                        VStack(spacing: 1) {
+                            Text("\"Over time, you spend too much time thinking about what you need to do,")
+                            Text("and not doing what you need to do.\"")
+                            Text("— Mel Robbins")
+                                .fontWeight(.medium)
+                        }
+                        .font(.caption2)
+                        .italic()
+                        .foregroundColor(.secondary.opacity(0.7))
+                        Spacer()
+                    }
+                    .padding(.bottom, 8)
                 }
             }
         }


### PR DESCRIPTION
## Changes

Adds two contextually-placed quotes:

### Ford Prefect (whimsical/time)
- **README.md**: Blockquote after opening tagline, before "What It Does"
- **About tab** (Preferences): Serif italic in accent color, below app description

### Mel Robbins (motivational/productivity)
- **README.md**: Blockquote at top of "Usage" section
- **Reports tab** footer: Subtle italic caption below Export button

### Build
- 0 errors, 0 warnings
- 228/228 tests pass

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author