### PR TITLE
docs: add missing agent/GUI launch and non-sudo instructions to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,18 +159,25 @@ wwk agent install
 
 # --- Option A: Homebrew ---
 brew tap Daylily-Informatics/tap
-brew install wwk                                          # CLI + agent
-brew install --cask Daylily-Informatics/tap/wellwhaddyaknow  # GUI app
-wwk agent install                                         # start agent at login
+brew install wwk                                             # CLI + agent
+brew install --cask Daylily-Informatics/tap/wellwhaddyaknow  # GUI app (requires sudo)
+wwk agent install                                            # register agent as login item
+open -a WellWhaddyaKnow                                     # launch the GUI
+
+# Non-admin users (no sudo): install the GUI to ~/Applications instead
+# mkdir -p ~/Applications
+# brew install --cask Daylily-Informatics/tap/wellwhaddyaknow --appdir=~/Applications
 
 # --- Option B: Build from source ---
 git clone https://github.com/Daylily-Informatics/well-whaddya-know.git
 cd well-whaddya-know
-./scripts/build-app.sh --release                          # builds .app bundle
-open .build/release/WellWhaddyaKnow.app                   # launch the GUI
+./scripts/build-app.sh --release                             # builds .app bundle
+wwk agent install                                            # register agent as login item
+open .build/release/WellWhaddyaKnow.app                      # launch the GUI
 
 # --- Verify ---
-wwk status          # should show current tracking state
+wwk agent status    # confirm agent is running
+wwk status          # current tracking state
 wwk today           # today's time breakdown by app
 ```
 


### PR DESCRIPTION
Quick Start was missing several steps a new user would need:

- **Option A (Homebrew)**: Added `open -a WellWhaddyaKnow` to actually launch the GUI after cask install. Added commented-out non-sudo alternative (`--appdir=~/Applications`).
- **Option B (Build from source)**: Added `wwk agent install` — without this the agent never starts.
- **Verify section**: Added `wwk agent status` as the first verification step.
- Clarified that cask install requires sudo.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author