### PR TITLE
feat: Option B — single formula installs CLI + agent + GUI

### DIFF
--- a/Sources/WellWhaddyaKnowCLI/Commands/GUICommand.swift
+++ b/Sources/WellWhaddyaKnowCLI/Commands/GUICommand.swift
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// GUICommand.swift - wwk gui subcommand to launch WellWhaddyaKnow.app
+
+import ArgumentParser
+import Foundation
+
+/// Launch the WellWhaddyaKnow GUI application.
+struct GUI: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "gui",
+        abstract: "Launch the WellWhaddyaKnow menu bar app"
+    )
+
+    @Option(name: .long, help: "Path to WellWhaddyaKnow.app (auto-detected if omitted)")
+    var appPath: String?
+
+    func run() throws {
+        let appBundle: String
+        if let explicit = appPath {
+            appBundle = explicit
+        } else if let found = findAppBundle() {
+            appBundle = found
+        } else {
+            throw CleanExit.message(
+                """
+                Could not locate WellWhaddyaKnow.app.
+
+                If installed via Homebrew:
+                  open "$(brew --prefix)/opt/wwk/WellWhaddyaKnow.app"
+
+                Or specify the path explicitly:
+                  wwk gui --app-path /path/to/WellWhaddyaKnow.app
+                """
+            )
+        }
+
+        guard FileManager.default.fileExists(atPath: appBundle) else {
+            throw CleanExit.message("App bundle not found at: \(appBundle)")
+        }
+
+        // Use /usr/bin/open which handles .app bundles correctly
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-a", appBundle]
+        try process.run()
+        process.waitUntilExit()
+
+        if process.terminationStatus != 0 {
+            throw CleanExit.message(
+                "Failed to open WellWhaddyaKnow.app (exit code \(process.terminationStatus))"
+            )
+        }
+    }
+}
+
+// MARK: - App Bundle Discovery
+
+/// Search for WellWhaddyaKnow.app in known locations.
+private func findAppBundle() -> String? {
+    // 1. Sibling to wwk binary (Homebrew Cellar layout)
+    let selfPath = CommandLine.arguments[0]
+    let selfDir = (selfPath as NSString).deletingLastPathComponent
+    // Homebrew installs wwk to bin/ and .app to the prefix root:
+    //   /opt/homebrew/Cellar/wwk/<ver>/bin/wwk
+    //   /opt/homebrew/Cellar/wwk/<ver>/WellWhaddyaKnow.app
+    let cellarApp = ((selfDir as NSString).deletingLastPathComponent as NSString)
+        .appendingPathComponent("WellWhaddyaKnow.app")
+    if isAppBundle(cellarApp) { return cellarApp }
+
+    // 2. Homebrew opt symlink (stable path)
+    for prefix in ["/opt/homebrew", "/usr/local"] {
+        let optApp = "\(prefix)/opt/wwk/WellWhaddyaKnow.app"
+        if isAppBundle(optApp) { return optApp }
+    }
+
+    // 3. ~/Applications (user install)
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    let userApp = "\(home)/Applications/WellWhaddyaKnow.app"
+    if isAppBundle(userApp) { return userApp }
+
+    // 4. /Applications (system-wide)
+    let sysApp = "/Applications/WellWhaddyaKnow.app"
+    if isAppBundle(sysApp) { return sysApp }
+
+    // 5. Development builds (relative to project root)
+    for config in ["release", "debug"] {
+        let devApp = ".build/\(config)/WellWhaddyaKnow.app"
+        if isAppBundle(devApp) { return devApp }
+    }
+
+    return nil
+}
+
+/// Check if a path looks like a valid .app bundle (has Contents/MacOS/).
+private func isAppBundle(_ path: String) -> Bool {
+    var isDir: ObjCBool = false
+    let macosDir = (path as NSString).appendingPathComponent("Contents/MacOS")
+    return FileManager.default.fileExists(atPath: macosDir, isDirectory: &isDir)
+        && isDir.boolValue
+}
+

--- a/Sources/WellWhaddyaKnowCLI/WWK.swift
+++ b/Sources/WellWhaddyaKnowCLI/WWK.swift
@@ -21,6 +21,7 @@ struct WWK: AsyncParsableCommand {
             Edit.self,
             Tag.self,
             Agent.self,
+            GUI.self,
             Doctor.self,
             DB.self,
         ],


### PR DESCRIPTION
## Option B: Single Formula Distribution

Replaces the dual-distribution model (formula + cask) with a single `brew install wwk` that installs all three components:

| Component | Location |
|-----------|----------|
| `wwk` | `/opt/homebrew/bin/wwk` |
| `wwkd` | `/opt/homebrew/bin/wwkd` |
| `WellWhaddyaKnow.app` | `/opt/homebrew/opt/wwk/WellWhaddyaKnow.app` |

### Changes

1. **`wwk gui` subcommand** (`GUICommand.swift`)
   - Discovers WellWhaddyaKnow.app from Homebrew Cellar, `~/Applications`, `/Applications`, or dev builds
   - Supports `--app-path` override

2. **Updated `Formula/wwk.rb`**
   - Builds all three products via `swift build`
   - Constructs `.app` bundle (Info.plist, embedded wwkd, launchd plist, PrivacyInfo)
   - Ad-hoc codesigns inner→outer
   - Installs `.app` to Cellar prefix
   - Updated caveats with `wwk gui` and `wwk agent install`

3. **Registered `GUI.self` in `WWK.swift`**

### Migration from cask

After merging, the cask (`wellwhaddyaknow.rb`) should be removed from the Homebrew tap. Users migrate with:
```bash
brew uninstall --cask wellwhaddyaknow  # remove old cask
brew reinstall wwk                      # installs CLI + agent + GUI
wwk agent install                       # register agent as login item
wwk gui                                 # launch menu bar app
```

### Testing
- `swift build`: 0 warnings
- `swift test`: 228/228 pass
- `wwk gui --help`: works correctly

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author